### PR TITLE
close #113 ✅ feat: 좋아요 일정 수 돌파할 때 알람 푸쉬

### DIFF
--- a/src/components/alarm/AlarmCard.tsx
+++ b/src/components/alarm/AlarmCard.tsx
@@ -6,21 +6,21 @@ import AlarmCardComment from "./alarmCardType/AlarmCardComment";
 import AlarmCardReport from "./alarmCardType/AlarmCardReport";
 import AlarmCardVote from "./alarmCardType/AlarmCardVote";
 import PostAlarm from "../modal/PostAlarm";
+import AlarmCardLike from "./alarmCardType/AlarmCardLike";
 
 export default function AlarmCard({ alarm }: { alarm: Alarm }) {
-  const alarmStore = useAlarmStore();
+  const { alarms, setAlarms, setUnReadCount, unReadCount } = useAlarmStore((state) => state);
   const [openPost, setOpenPost] = useState(false);
   const [postData, setPostData] = useState<Post | null>(null);
 
   const renderContent = () => {
     switch (alarm.type) {
       case "votes":
-        // alarm reference_id는 무조건 vote
         return <AlarmCardVote alarm={alarm} setPostData={setPostData} openPost={openPost} />;
       case "comments":
         return <AlarmCardComment alarm={alarm} setPostData={setPostData} openPost={openPost} />;
       case "likes":
-        return;
+        return <AlarmCardLike alarm={alarm} setPostData={setPostData} post={postData} />;
       case "reports":
         return <AlarmCardReport />;
     }
@@ -28,7 +28,10 @@ export default function AlarmCard({ alarm }: { alarm: Alarm }) {
 
   const deleteHandler = async () => {
     await deleteAlarmAPI(alarm.uid);
-    alarmStore.setAlarms(alarmStore.alarms.filter((item) => item.uid !== alarm.uid));
+    if (!alarm.is_read) {
+      setUnReadCount(unReadCount - 1);
+    }
+    setAlarms(alarms.filter((item) => item.uid !== alarm.uid));
   };
 
   return (

--- a/src/components/alarm/alarmCardType/AlarmCardLike.tsx
+++ b/src/components/alarm/alarmCardType/AlarmCardLike.tsx
@@ -1,0 +1,34 @@
+import { useEffect, type Dispatch, type SetStateAction } from "react";
+import { getPostByUid } from "../../../api/postGet";
+import likeImg from "../../../assets/posts/likeFilled.svg";
+
+export default function AlarmCardLike({
+  alarm,
+  setPostData,
+  post,
+}: {
+  alarm: Alarm;
+  setPostData: Dispatch<SetStateAction<Post | null>>;
+  post: Post | null;
+}) {
+  useEffect(() => {
+    const getPost = async () => {
+      const post = await getPostByUid(alarm.reference_id);
+      setPostData(post);
+    };
+
+    getPost();
+  }, [alarm.uid]);
+
+  return (
+    <>
+      <p className="p-4.5 pb-0 text-[13px] underline text-[#d3cfcf] hover:text-[#bfbcbc]">
+        {post?.post_title}
+      </p>
+      <p className="flex p-4.5 font-normal text-[11px]">
+        <img className="mr-[5px]" src={likeImg} alt="likeImg" />
+        해당 게시글의 좋아요가 {post?.like_count}개가 되었습니다!
+      </p>
+    </>
+  );
+}


### PR DESCRIPTION
수파베이스의 트리거 함수를 사용함

1. 좋아요를 누를 때 트리거 함수가 호출
2. 현재 게시글의 좋아요 수를 체크
3. 정해 놓은 좋아요 수 (3, 10, 50) 가 넘을 때 알람을 보낸다.
4. 취소하고 다시 누르려고 할때 기존 알람테이블에서 post_id, likes(type)으로 30초동안 중복 체크를 한다.

예외사항
AlarmCard 컴포넌트에서 deleteHandler() 함수에 아직 읽지 않은 알람을 삭제 했을 때 unReadCount - 1 되도록 수정 